### PR TITLE
avoid constructing `Vector{Tuple{Type{...},Type{...}}}`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ using Test
         @testset "Number of rounds: $num_rounds" for num_rounds in [1; 10]
             game = game_name(num_rounds)
             num_players = length(size(game.rewards(1)))
-            @testset "Battle: $strategies_pool" for strategies_pool in collect(Iterators.product(fill(SquidGame.AVAILABLE_STRATEGIES, num_players)...))
+            @testset "Battle: $strategies_pool" for strategies_pool in Iterators.product(fill(SquidGame.AVAILABLE_STRATEGIES, num_players)...)
                 strategies = Vector{Type{<:Strategy}}()
                 for strategy in strategies_pool
                     push!(strategies, strategy)


### PR DESCRIPTION
This commit adapts to the incoming upstream change of the Julia compiler.
More specifically this change is necessary after JuliaLang/julia#44725,
which fixes an internal bug of the compiler, which in turn makes the test
suite of SquidGame fail without this change (if you're interested, please
see <https://github.com/JuliaLang/julia/pull/44725#issuecomment-1078641874>).